### PR TITLE
fix: fixed a problem with certs folder permissions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   certs:
     image: psmiraglia/spid-compliant-certificates
     volumes:
-        - ./certs:/tmp/certs:rw
+        - certs-volume:/tmp/certs
     entrypoint: spid-compliant-certificates generator --key-size 3072 --common-name "A.C.M.E" --days 365 --entity-id https://spid.acme.it --locality-name Roma --org-id "PA:IT-c_h501" --org-name "A Company Making Everything" --sector public --key-out /tmp/certs/private.key --crt-out /tmp/certs/public.cert
 
   taiga-gateway:
@@ -54,7 +54,7 @@ services:
     volumes:
       - taiga-static-data:/taiga-back/static
       - taiga-media-data:/taiga-back/media
-      - ./certs:/certs
+      - certs-volume:/certs
 
     networks:
       - taiga
@@ -96,6 +96,7 @@ volumes:
   taigadbdata:
   taiga-static-data:
   taiga-media-data:
+  certs-volume:
 
 networks:
   taiga:

--- a/taiga-contrib-inps/back/setup.py
+++ b/taiga-contrib-inps/back/setup.py
@@ -21,6 +21,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         "djangosaml2-spid @ git+https://git@github.com/italia/spid-django.git@main#egg=djangosaml2-spid",
+        "djangosaml2 < 1.5.0",
         "spid_compliant_certificates @ git+https://git@github.com/italia/spid-compliant-certificates-python.git@main#egg=spid_compliant_certificates",
     ],
     setup_requires=[

--- a/taiga-contrib-inps/spid_inps/setup.py
+++ b/taiga-contrib-inps/spid_inps/setup.py
@@ -21,6 +21,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         "djangosaml2-spid @ git+https://git@github.com/italia/spid-django.git@main#egg=djangosaml2-spid",
+        "djangosaml2 < 1.5.0",
         "spid_compliant_certificates @ git+https://git@github.com/italia/spid-compliant-certificates-python.git@main#egg=spid_compliant_certificates"
     ],
     setup_requires=[


### PR DESCRIPTION
## Description

Switched from bind mount to named volume for 'certs' service to solve the issue of not having writing permission in ./certs directory on host machine.


This PR tackles:

- ...
- ...
- ...

In particular, the ...

## Checklist


- [ ] I have followed the indications in the [CONTRIBUTING](https://github.com/INPS-it/taiga-inps-bug-tracking/blob/main/CONTRIBUTING.md).
- [ ] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [ ] I have written new tests for my core changes, as applicable.
- [ ] I have successfully run tests with my changes locally.
- [ ] It is ready for review! :rocket:

## Fixes

- Fixes #27
