### PR TITLE
Fix/cert write permission

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,9 +4,8 @@ services:
   certs:
     image: psmiraglia/spid-compliant-certificates
     volumes:
-        - ./certs:/tmp/certs:rw
+      - ./certs:/tmp/certs:rw
     entrypoint: spid-compliant-certificates generator --key-size 3072 --common-name "A.C.M.E" --days 365 --entity-id https://spid.acme.it --locality-name Roma --org-id "PA:IT-c_h501" --org-name "A Company Making Everything" --sector public --key-out /tmp/certs/private.key --crt-out /tmp/certs/public.cert
-
   taiga-gateway:
     image: nginx:1.19-alpine
     ports:
@@ -55,7 +54,6 @@ services:
       - taiga-static-data:/taiga-back/static
       - taiga-media-data:/taiga-back/media
       - ./certs:/certs
-
     networks:
       - taiga
   taiga-db:
@@ -80,7 +78,6 @@ services:
       - taiga
     volumes:
       - taigadbdata:/var/lib/postgresql/data
-
   spid-saml-check:
     image: italia/spid-saml-check
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   certs:
     image: psmiraglia/spid-compliant-certificates
     volumes:
-      - ./certs:/tmp/certs:rw
+      - certs-volume:/tmp/certs
     entrypoint: spid-compliant-certificates generator --key-size 3072 --common-name "A.C.M.E" --days 365 --entity-id https://spid.acme.it --locality-name Roma --org-id "PA:IT-c_h501" --org-name "A Company Making Everything" --sector public --key-out /tmp/certs/private.key --crt-out /tmp/certs/public.cert
   taiga-gateway:
     image: nginx:1.19-alpine
@@ -53,7 +53,7 @@ services:
     volumes:
       - taiga-static-data:/taiga-back/static
       - taiga-media-data:/taiga-back/media
-      - ./certs:/certs
+      - certs-volume:/certs
     networks:
       - taiga
   taiga-db:
@@ -93,6 +93,7 @@ volumes:
   taigadbdata:
   taiga-static-data:
   taiga-media-data:
+  certs-volume:
 
 networks:
   taiga:


### PR DESCRIPTION
<!--- IMPORTANT: Please review [how to contribute](https://github.com/INPS-it/taiga-inps-bug-tracking/blob/main/CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->

## Description

<!--- Describe in detail the proposed mods -->

This PR tackles an issue that prevents generation of X.509 certificate and private key during setup with Docker.

## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [] I have followed the indications in the [CONTRIBUTING](https://github.com/INPS-it/taiga-inps-bug-tracking/blob/main/CONTRIBUTING.md).
- [ ] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [ ] I have written new tests for my core changes, as applicable.
- [] I have successfully run tests with my changes locally.
- [] It is ready for review! :rocket:
